### PR TITLE
refactor: Remove shapes.inc fallback for avatars in ChatArea

### DIFF
--- a/src/components/ChatArea.tsx
+++ b/src/components/ChatArea.tsx
@@ -41,28 +41,21 @@ export default function ChatArea() {
     }
     // --- Simulation End ---
 
-    const fetchAndSetAvatar = async () => {
+    const determineAvatar = () => { // Renamed from fetchAndSetAvatar
       if (simulatedAppShapeData?.customAvatarUrl) {
         setBotAvatarUrl(simulatedAppShapeData.customAvatarUrl);
         console.log('Using custom avatar:', simulatedAppShapeData.customAvatarUrl);
-      } else if (simulatedAppShapeData?.vanityUrl) {
-        console.log('No custom avatar, attempting to fetch from shapes.inc for:', simulatedAppShapeData.vanityUrl);
-        const profileInfo = await ShapesAPI.fetchShapeProfileInfo(simulatedAppShapeData.vanityUrl);
-        if (profileInfo) {
-          const shapesIncAvatar = ShapesAPI.getShapeAvatarUrlFromProfile(profileInfo);
-          setBotAvatarUrl(shapesIncAvatar);
-          console.log('Using shapes.inc avatar:', shapesIncAvatar);
-        } else {
-          setBotAvatarUrl(null);
-          console.log('No avatar found from shapes.inc for:', simulatedAppShapeData.vanityUrl);
-        }
       } else {
-        setBotAvatarUrl(null); // No data to fetch any avatar
-        console.log('No shape data (serverId or simulatedAppShapeData) to determine avatar.');
+        setBotAvatarUrl(null);
+        if (serverId) { // Only log if we expected to find a shape
+            console.log('No custom avatar found for shape:', serverId, '. Using null.');
+        } else {
+            console.log('No serverId, avatar set to null.');
+        }
       }
     };
 
-    fetchAndSetAvatar();
+    determineAvatar();
   }, [serverId]); // serverId determines simulatedAppShapeData
 
   useEffect(() => {


### PR DESCRIPTION
### **User description**
Updates ChatArea.tsx to only use customAvatarUrl from the application's shape data. If no customAvatarUrl is present, the avatar will be null, relying on Message.tsx to display a default Bot icon.

This removes the previous logic that would fetch from the shapes.inc API as a fallback, simplifying avatar handling to focus on your uploaded images.


___

### **PR Type**
enhancement


___

### **Description**
- Removed fallback to shapes.inc API for avatar fetching

- Now only uses customAvatarUrl from shape data for avatars

- Sets avatar to null if no customAvatarUrl is present

- Improved logging for avatar selection process


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>ChatArea.tsx</strong><dd><code>Refactor avatar selection to remove shapes.inc fallback</code>&nbsp; &nbsp; </dd></summary>
<hr>

src/components/ChatArea.tsx

<li>Removed logic to fetch avatars from shapes.inc API as a fallback<br> <li> Refactored avatar selection to only use customAvatarUrl<br> <li> Added and clarified logging for avatar determination<br> <li> Renamed function for clarity (fetchAndSetAvatar → determineAvatar)


</details>


  </td>
  <td><a href="https://github.com/bgill55/Shapeshift/pull/6/files#diff-fb0b0f7fdca4f230e7827a1ee052c3e7294cb70e065fc6c78895f0a3ebbc9b03">+7/-14</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>